### PR TITLE
OPT Bulkhead Profile Update

### DIFF
--- a/GameData/SDVBAO/OPT/Localization/en-us.cfg
+++ b/GameData/SDVBAO/OPT/Localization/en-us.cfg
@@ -1,0 +1,17 @@
+Localization
+{
+  en-us
+  {
+    // Bulkhead codes
+    // ---------------
+    // OPT
+    #LOC_VABOrganizer_Bulkhead_OPT_h = H
+    #LOC_VABOrganizer_Bulkhead_OPT_j = J
+    #LOC_VABOrganizer_Bulkhead_OPT_k = K
+    #LOC_VABOrganizer_Bulkhead_OPT_kh = KH
+    #LOC_VABOrganizer_Bulkhead_OPT_Stail = Stail
+    #LOC_VABOrganizer_Bulkhead_OPT_Avatar = Avatar
+    #LOC_VABOrganizer_Bulkhead_OPT_Chimera = Chimera
+    #LOC_VABOrganizer_Bulkhead_OPT_humpback = Humpback
+  }
+}

--- a/GameData/SDVBAO/OPT/OPTBulkheadProfiles.cfg
+++ b/GameData/SDVBAO/OPT/OPTBulkheadProfiles.cfg
@@ -1,0 +1,57 @@
+
+ORGANIZERBULKHEAD
+{
+  name = Chimera
+  Size = 3.75
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_Chimera
+  Color = 0.26, 0.36, 0.99
+}
+ORGANIZERBULKHEAD
+{
+  name = Avatar
+  Size = 4.9
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_Avatar
+  Color = 0.99, 0.70, 0.26
+}
+ORGANIZERBULKHEAD
+{
+  name = Stail
+  Size = 5.0
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_Stail
+  Color = 0.7, 0.7, 0.7
+}
+ORGANIZERBULKHEAD
+{
+  name = j
+  Size = 5.1
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_j
+  Color = 0.19, 0.66, 0.51
+}
+ORGANIZERBULKHEAD
+{
+  name = h
+  Size = 7.7
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_h
+  Color = 0.72, 0.26, 0.99
+}
+ORGANIZERBULKHEAD
+{
+  name = k
+  Size = 7.6
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_k
+  Color = 0.46, 0.2, 0.66
+}
+ORGANIZERBULKHEAD
+{
+  name = kh
+  Size = 8.0
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_kh
+  Color = 0.66, 0.2, 0.2
+}
+ORGANIZERBULKHEAD
+{
+  name = Humpback
+  Size = 7.75
+  Label = #LOC_VABOrganizer_Bulkhead_OPT_humpback
+  Color = 0.96, 0.99, 0.26
+}


### PR DESCRIPTION
Adds in Bulkhead Profiles, based on the Bulkheads defined in `OPT_Reconfig\CBP\bulkheadProfiles.cfg`. I went with colors that were unique from the ones included in stock VABOrganizer, but they can be changed to whatever other color best fits.

Confirmed working with the latest beta version of OPT.


![image](https://github.com/user-attachments/assets/03f4baf9-e072-4925-b580-40abce62ed33)
