### PR TITLE
Adds SCANsat compatibility

### DIFF
--- a/GameData/SDVBAO/SCANsat/Localization/en-us.cfg
+++ b/GameData/SDVBAO/SCANsat/Localization/en-us.cfg
@@ -1,0 +1,11 @@
+Localization
+{
+  en-us
+  {
+    // Science - SCANsat
+    #LOC_VABOrganizer_Subcategory_SCANsatMulti = Multispectral Scanners
+    #LOC_VABOrganizer_Subcategory_SCANsatAltimetry = Altimetry Scanners
+    #LOC_VABOrganizer_Subcategory_SCANsatVisual = Visual Scanners
+
+  }
+}

--- a/GameData/SDVBAO/SCANsat/SCANsat_VABO.cfg
+++ b/GameData/SDVBAO/SCANsat/SCANsat_VABO.cfg
@@ -1,0 +1,32 @@
+// Config for SCANsat Parts
+
+/// Science
+/// -------------
+@PART[SCANsat_Scanner24|scansat-multi-modis-1|scansat-multi-abi-1|scansat-multi-msi-1]:FOR[SCANsat]:NEEDS[SCANsat&VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = SCANsatMulti
+  }
+}
+@PART[SCANsat_Scanner|SCANsat_Scanner2|scansat-radar-poseidon-3b-1|scansat-radar-seasat-1|scansat-sar-paz-1|scansat-sar-radarsat-2-1|scansat-sar-tandem-l-1]:FOR[SCANsat]:NEEDS[SCANsat&VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = SCANsatAltimetry
+  }
+}
+@PART[SCANsat_Scanner32|SCANsat_Tracker|scansat-exomars-1|scansat-recon-ikonos-1|scansat-recon-worldview-3-1|scansat-recon-kh11-1]:FOR[SCANsat]:NEEDS[SCANsat&VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = SCANsatVisual
+  }
+}
+@PART[scansat-resources-crism-1|scansat-resources-mise-1|scansat-resources-hyperion-1]:FOR[SCANsat]:NEEDS[SCANsat&VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = resourceScanners
+  }
+}

--- a/GameData/SDVBAO/SCANsat/SCANsat_subcategories.cfg
+++ b/GameData/SDVBAO/SCANsat/SCANsat_subcategories.cfg
@@ -1,0 +1,27 @@
+// Additional subcategories for SCANsat parts
+// resource scanners within SCANsat use the existing 'resourceScanners' subcategory from VAB Organizer
+
+ORGANIZERSUBCATEGORY:NEEDS[SCANsat&VABOrganizer]
+{
+  // for scanners like Multispectral that do biome and more types (multi)
+  name = SCANsatMulti
+  Label = #LOC_VABOrganizer_Subcategory_SCANsatMulti    // Multispectral Scanners
+  Priority = 27
+  CategoryPriority = 65
+}
+ORGANIZERSUBCATEGORY:NEEDS[SCANsat&VABOrganizer]
+{
+  // for primarily both LoRes and HiRes Altimetry scanners (radar and sar)
+  name = SCANsatAltimetry
+  Label = #LOC_VABOrganizer_Subcategory_SCANsatAltimetry    // Altimetry Scanners
+  Priority = 28
+  CategoryPriority = 65
+}
+ORGANIZERSUBCATEGORY:NEEDS[SCANsat&VABOrganizer]
+{
+  // for primarily both BTDT and Visual scanners (btdt and recon)
+  name = SCANsatVisual
+  Label = #LOC_VABOrganizer_Subcategory_SCANsatVisual   // Visual Scanners
+  Priority = 29
+  CategoryPriority = 65
+}


### PR DESCRIPTION
Adds SCANsat compatibility in VAB Organizer through three additional subcategories:

- **Multispectral Scanners** [`SCANsatMulti`] - for scanners like Multispectral that do biome and more types
- **Altimetry Scanners** [`SCANsatAltimetry`] - for primarily both LoRes and HiRes Altimetry scanners
- **Visual Scanners** [`SCANsatVisual`] - for primarily both BTDT and Visual scanners

Resource scanners in SCANsat use the existing **Resource Scanners** [`resourceScanners`] subcategory in VAB Organizer.