### PR TITLE
Updates Universal Storage 2 compatibility

### DIFF
--- a/GameData/SDVBAO/USII/USIIVABO.cfg
+++ b/GameData/SDVBAO/USII/USIIVABO.cfg
@@ -1,148 +1,11 @@
-@PART[USCylindricalShroud1500]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
+// Config for Universal Storage 2 Parts
 
-@PART[USCylindricalShroud125]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
+/// Aero
+///--------------
 
-@PART[USCylindricalShroud0625]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[madv_cap]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USPenticore]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = structure
-    }
-}
-
-@PART[USAdaptorShroud1250]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USAdaptorShroud1250Vostok]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USAdaptorShroud1500]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USOctocore]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = structure
-    }
-}
-
-@PART[USCylindricalShroud250]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USCylindricalShroud125ResizedTo1875-1]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USAdaptorShroud1250Soyuz]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USCylindricalShroud1500ResizedTo1875-2]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USAdaptorShroud1875]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = serviceBays
-    }
-}
-
-@PART[USBatteryWedge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = batteries
-    }
-}
-
-@PART[USFuelCellMedium]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = fuelCells
-    }
-}
-
-@PART[USFuelCellSmal]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = fuelCells
-    }
-}
-
-@PART[USRTGWedge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = fusionReactors
-    }
-}
-
-@PART[USCargoStorageWedge]:FOR[VABOrganizer]
+/// Cargo
+/// -------------
+@PART[USCargoStorageWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
 {
     %VABORGANIZER
     {
@@ -150,23 +13,130 @@
     }
 }
 
-@PART[USHydrazineWedge]:FOR[VABOrganizer]
+/// Command
+/// -------------
+@PART[USSingleProbeCore|USDoubleProbeCore]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = monopropellant
+        %organizerSubcategory = probes
     }
 }
 
-@PART[USAerozineWedge]:FOR[VABOrganizer]
+/// Communication
+/// -------------
+
+/// Control
+/// -------------
+@PART[USGuidanceComputer]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&kOS]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = probes
+    }
+}
+
+/// Coupling
+/// -------------
+@PART[USACDTiny|USACDSmall|USACDMedium|USACDLarge|USACD1500]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = decouplers
+    }
+}
+
+/// Electrical
+/// -------------
+@PART[USBatteryWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = batteries
+    }
+}
+@PART[USFuelCellSmal|USFuelCellMedium]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fuelCells
+    }
+}
+@PART[USRTGWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rtgs
+    }
+}
+
+/// Engines
+/// -------------
+
+/// Fuel
+/// -------------
+@PART[USAerozineWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
 {
     %VABORGANIZER
     {
         %organizerSubcategory = lfo
     }
 }
+@PART[USHydrazineWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = monoprop
+    }
+}
 
-@PART[USFluidSpectroWedge]:FOR[VABOrganizer]
+/// Ground
+/// -------------
+
+/// Payload
+/// -------------
+@PART[USCylindricalShroud*|USAdaptorShroud*]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = serviceBays
+    }
+}
+@PART[USQuadcore|USPenticore|USHexcore|USOctocore]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = hubs
+    }
+}
+@PART[USKASRadial|USKASWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&KIS]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = cargoStorage
+    }
+}
+
+/// Robotics
+/// -------------
+
+/// Science
+/// -------------
+@PART[USDataStorageWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = scienceStorage
+    }
+}
+@PART[USBasicMicroSatWedge|USAdvancedMicroSatWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = probes
+    }
+}
+@PART[USMapCamWedge|USAccelGravWedge|USGooBayWedge|USMatBayWedge|USThermoBaroWedge|USFluidSpectroWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
 {
     %VABORGANIZER
     {
@@ -174,195 +144,81 @@
     }
 }
 
-@PART[USCarbonDioxideWedge]:FOR[VABOrganizer]
+/// Structural
+/// -------------
+
+/// Thermal
+/// -------------
+
+/// Utility
+/// -------------
+@PART[USElektron]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&!IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = waste
+        %organizerSubcategory = resources
     }
 }
-
-@PART[USFoodWedge]:FOR[VABOrganizer]
+@PART[USSabatier]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = food
+        %organizerSubcategory = resources
     }
 }
-
-@PART[USWaterWedge]:FOR[VABOrganizer]
+@PART[USWaterPurifier]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = water
+        %organizerSubcategory = resources
     }
 }
-
-@PART[USOxygenWedge]:FOR[VABOrganizer]
+@PART[USOxygenWedge|USHydrogenWedge|USComboLifesupportWedge|USRadialTanks]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = oxygen
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USSolidWasteWedge]:FOR[VABOrganizer]
+@PART[USFoodWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = waste
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USHydrogenWedge]:FOR[VABOrganizer]
+@PART[USWaterWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&!IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = monoprop
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USElektron]:FOR[VABOrganizer]
+@PART[USCarbonDioxideWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = utility
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USComboLifesupportWedge]:FOR[VABOrganizer]
+@PART[USGreyWaterWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism|USILifeSupport]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = lifeSupport
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USGreyWaterWedge]:FOR[VABOrganizer]
+@PART[USSolidWasteWedge]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&VABOrganizer&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = waste
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USWaterPurifier]:FOR[VABOrganizer]
+@PART[USEVAX]:FOR[UniversalStorage2]:NEEDS[UniversalStorage2&KIS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = water
+        %organizerSubcategory = cargoContainers
     }
 }
-
-@PART[USRadialTanks]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = monoprop
-    }
-}
-
-@PART[USSabatier]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = utility
-    }
-}
-
-@PART[USDoubleProbeCore]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = probes
-    }
-}
-
-@PART[USSingleProbeCore]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = probes
-    }
-}
-
-@PART[USACD1500]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = decouplers
-    }
-}
-
-@PART[USACDLarge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = decouplers
-    }
-}
-
-@PART[USACDMedium]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = decouplers
-    }
-}
-
-@PART[USACDSmall]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = decouplers
-    }
-}
-
-@PART[USACDTiny]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = decouplers
-    }
-}
-
-@PART[USQuadcore|USPenticore|USHexcore|USOctocore]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = hubs
-    }
-}
-
-@PART[USDataStorageWedge|USMatBayWedge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = scienceStorage
-    }
-}
-
-@PART[USBasicMicroSatWedge|USAdvancedMicroSatWedge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = scienceStorage
-    }
-}
-
-@PART[USMapCamWedge]:FOR[VABOrganizer]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = scienceStorage
-    }
-}
-
-@PART[USAccelGravWedge|USGooBayWedge|USThermoBaroWedge]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = scienceStorage
-    }
-}
-


### PR DESCRIPTION
Makes four main changes throughout:
- Rearrange patches within the file to follow a template of categories the parts use.
- Updates assigned subcategories parts use to those available in VAB Organizer.*
- Includes missing parts.
- Adds missing `NEEDS` for parts.

As a small bonus, also decreases file size.

*_Recommend life support mods (TacLifeSupport, Kerbalism, SnacksUtils, USILifeSupport, IFILS, etc.) add more granularity to the life support components that Universal Storage 2 adds. If they do not or those mods are not used, this at least tries to include them in a semi-appropriate subcategory rather than miscellaneous._