### PR TITLE
Corrects my mistakes in JX2Antenna patch

### DIFF
--- a/GameData/SDVBAO/JX2Antenna/JX2Antenna_VABO.cfg
+++ b/GameData/SDVBAO/JX2Antenna/JX2Antenna_VABO.cfg
@@ -2,7 +2,14 @@
 
 /// Communication
 /// -------------
-@PART[ju1MDA|jw1MDA|jx2LDA]:FOR[JX2Antenna]:NEEDS[JX2Antenna&VABOrganizer]
+@PART[jw1MDA]:NEEDS[JX2Antenna&VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = direct
+  }
+}
+@PART[ju1MDA|jx2LDA]:NEEDS[JX2Antenna&VABOrganizer]
 {
   %VABORGANIZER
   {

--- a/GameData/SDVBAO/JX2Antenna/JX2Antenna_VABO.cfg
+++ b/GameData/SDVBAO/JX2Antenna/JX2Antenna_VABO.cfg
@@ -2,7 +2,7 @@
 
 /// Communication
 /// -------------
-@PART[ju1MDA|jw1MDA|jx2LDA]:FOR[JX2Antenna]:NEEDS[VABOrganizer]
+@PART[ju1MDA|jw1MDA|jx2LDA]:FOR[JX2Antenna]:NEEDS[JX2Antenna&VABOrganizer]
 {
   %VABORGANIZER
   {


### PR DESCRIPTION
- Adds the missing `JX2Antenna` to `NEEDS`.
- Corrects subcategory assignment for one antenna.
- Removes unnecessary `FOR` use in the patch.