### PR TITLE
Adds compatibility to DMagic Orbital Science

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
@@ -1,0 +1,93 @@
+// Config for DMagic Orbital Science Parts
+
+/// Science
+/// -------------
+//// OversizeScience folder
+@PART[dmReconSmall|dmReconLarge|dmSIGINT|dmSIGINT.Small|dmSIGINT.End]:NEEDS[DMagicOrbitalScience]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = science
+    }
+}
+//// ProbeScience folder
+@PART[dmASERT|dmGoreSat|dmImagingPlatform|dmmagBoom|rpwsAnt|dmscope|dmSoilMoisture|dmSolarCollector]:NEEDS[DMagicOrbitalScience]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = science
+    }
+}
+//// RoverScience folder
+@PART[dmASERT|dmAnomScanner|dmBathymetry|dmbioDrill|dmDAN|dmsurfacelaser|dmRoverGoo|dmRoverMat|dmSeismicPod|dmSeismicHammer|dmXRay]:NEEDS[DMagicOrbitalScience]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = science
+    }
+}
+@PART[dmbioDrill]:AFTER[VABOrganizer]:NEEDS[DMagicOrbitalScience] // VAB Organizer moves it into 'resources' subcategory since it has 'Drill' in its name
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = science
+    }
+}
+//// UniversalStorageScience folder
+@PART[dmUS2Asert|dmUS2GoreSat|dmUS2ImagingPlatform|dmUS2MagBoom|dmUS2RPWS|dmUS2Scope|dmUS2SoilMoisture|dmUS2SolarParticles]:NEEDS[DMagicOrbitalScience&UniversalStorage2]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = science
+    }
+}
+//// OPTIONAL SCANsat categorization: moves those with SCANsat integration to subcategories used by SCANsat VAB Organizer patch (not recommended as default for Career and Science since science matters more, in the beginning at least)
+// @PART[dmmagBoom]:NEEDS[DMagicOrbitalScience&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = resourceScanners
+//     }
+// }
+// @PART[dmUS2MagBoom]:NEEDS[DMagicOrbitalScience&UniversalStorage2&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = resourceScanners
+//     }
+// }
+// @PART[dmSoilMoisture]:NEEDS[DMagicOrbitalScience&CommunityResourcePack&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = resourceScanners
+//     }
+// }
+// @PART[dmUS2SoilMoisture]:NEEDS[DMagicOrbitalScience&CommunityResourcePack&UniversalStorage2&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = resourceScanners
+//     }
+// }
+// @PART[dmImagingPlatform]:NEEDS[DMagicOrbitalScience&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = SCANsatMulti
+//     }
+// }
+// @PART[dmUS2ImagingPlatform]:NEEDS[DMagicOrbitalScience&UniversalStorage2&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = SCANsatMulti
+//     }
+// }
+// @PART[dmAnomScanner]:NEEDS[DMagicOrbitalScience&SCANsat]
+// {
+//     %VABORGANIZER
+//     {
+//         %organizerSubcategory = SCANsatVisual
+//     }
+// }

--- a/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
@@ -74,20 +74,20 @@
 // {
 //     %VABORGANIZER
 //     {
-//         %organizerSubcategory = SCANsatMulti
+//         %organizerSubcategory = ScanMulti
 //     }
 // }
 // @PART[dmUS2ImagingPlatform]:NEEDS[DMagicOrbitalScience&UniversalStorage2&SCANsat]
 // {
 //     %VABORGANIZER
 //     {
-//         %organizerSubcategory = SCANsatMulti
+//         %organizerSubcategory = ScanMulti
 //     }
 // }
 // @PART[dmAnomScanner]:NEEDS[DMagicOrbitalScience&SCANsat]
 // {
 //     %VABORGANIZER
 //     {
-//         %organizerSubcategory = SCANsatVisual
+//         %organizerSubcategory = ScanVisual
 //     }
 // }


### PR DESCRIPTION
- Assigns a VAB Organizer subcategory to DMagic Orbital Science parts.
- Includes user-optional patches to add SCANsat-compatible parts to subcategories used by SCANsat patch instead. By default, it does not since they are commented-out.