### PR TITLE
Adds Resource Utlilization subcategory

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -6,6 +6,7 @@ Localization
     #LOC_VABOrganizer_Subcategory_DataCoreChips = DataCore Chips
     // Shared
     #LOC_VABOrganizer_Subcategory_Cores = Cores
+    #LOC_VABOrganizer_Subcategory_resourceUtilization = Resource Utilization
     #LOC_VABOrganizer_Subcategory_LifeSupport = Life Support
     #LOC_VABOrganizer_Subcategory_ScanMulti = Multispectral Scanners
     #LOC_VABOrganizer_Subcategory_ScanAltimetry = Altimetry Scanners

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -9,6 +9,7 @@ ORGANIZERSUBCATEGORY
 // Used by USII
 ORGANIZERSUBCATEGORY
 {
+  // currently for ISRUs, parts used towards life support
   name = resourceUtilization
   Label = #LOC_VABOrganizer_Subcategory_resourceUtilization   // Resource Utilization
   Priority = 82
@@ -17,7 +18,7 @@ ORGANIZERSUBCATEGORY
 // Used by Kerbalism, USII
 ORGANIZERSUBCATEGORY
 {
-  // for life support-related parts
+  // for direct needs requirements to live by life support mods (food, oxygen, rad-x, water, etc.)
   name = LifeSupport
   Label = #LOC_VABOrganizer_Subcategory_LifeSupport    // Life Support
   Priority = 83

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -6,14 +6,22 @@ ORGANIZERSUBCATEGORY
     Priority = 5
     CategoryPriority = 25
 }
+// Used by USII
+ORGANIZERSUBCATEGORY
+{
+  name = resourceUtilization
+  Label = #LOC_VABOrganizer_Subcategory_resourceUtilization   // Resource Utilization
+  Priority = 82
+  CategoryPriority = 70
+}
 // Used by Kerbalism, USII
 ORGANIZERSUBCATEGORY
 {
   // for life support-related parts
   name = LifeSupport
   Label = #LOC_VABOrganizer_Subcategory_LifeSupport    // Life Support
-  Priority = 30
-  CategoryPriority = 60
+  Priority = 83
+  CategoryPriority = 70
 }
 // Used by SCANsat, OrbitalScience
 ORGANIZERSUBCATEGORY

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/SubcategoryPatchModification.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/SubcategoryPatchModification.cfg
@@ -1,0 +1,10 @@
+// For modifications to how VAB Organizer assigns parts
+
+// moves ISRUs to the Resource Utilization subcategory instead of Harvesting
+@PART[*ISRU*]:FOR[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = resourceUtilization
+  }
+}

--- a/GameData/VABOrganizer-Sheepdog/USII/USIIVABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/USII/USIIVABO.cfg
@@ -1,8 +1,5 @@
 // Config for Universal Storage 2 Parts
 
-/// Aero
-///--------------
-
 /// Cargo
 /// -------------
 @PART[USCargoStorageWedge]:NEEDS[UniversalStorage2]
@@ -22,9 +19,6 @@
         %organizerSubcategory = probes
     }
 }
-
-/// Communication
-/// -------------
 
 /// Control
 /// -------------
@@ -70,9 +64,6 @@
     }
 }
 
-/// Engines
-/// -------------
-
 /// Fuel
 /// -------------
 @PART[USAerozineWedge]:NEEDS[UniversalStorage2]
@@ -89,9 +80,6 @@
         %organizerSubcategory = monoprop
     }
 }
-
-/// Ground
-/// -------------
 
 /// Payload
 /// -------------
@@ -117,9 +105,6 @@
     }
 }
 
-/// Robotics
-/// -------------
-
 /// Science
 /// -------------
 @PART[USDataStorageWedge]:NEEDS[UniversalStorage2]
@@ -144,59 +129,71 @@
     }
 }
 
-/// Structural
-/// -------------
-
-/// Thermal
-/// -------------
-
 /// Utility
 /// -------------
 @PART[USElektron]:NEEDS[UniversalStorage2&!IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = resources
+        %organizerSubcategory = resourceUtilization
     }
 }
 @PART[USSabatier]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = resources
-    }
-}
-
-@PART[USRadialTanks]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = resources
+        %organizerSubcategory = resourceUtilization
     }
 }
 @PART[USWaterPurifier]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = LifeSupport
+        %organizerSubcategory = resourceUtilization
     }
 }
-@PART[USOxygenWedge|USHydrogenWedge]:NEEDS[UniversalStorage2]
+@PART[USCarbonDioxideWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USGreyWaterWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|USILifeSupport]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USSolidWasteWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USOxygenWedge|USHydrogenWedge|USComboLifesupportWedge|USRadialTanks]:NEEDS[UniversalStorage2] // base
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USOxygenWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|IFILS] // if using a life support mod that requires oxygen as a primary need
 {
     %VABORGANIZER
     {
         %organizerSubcategory = LifeSupport
     }
 }
-
-@PART[USComboLifesupportWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
+@PART[USComboLifesupportWedge|USRadialTanks]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS] // if using a life support mod
 {
     %VABORGANIZER
     {
         %organizerSubcategory = LifeSupport
     }
 }
-
 @PART[USFoodWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
 {
     %VABORGANIZER
@@ -204,38 +201,24 @@
         %organizerSubcategory = LifeSupport
     }
 }
-@PART[USWaterWedge]:NEEDS[UniversalStorage2&!IFILS]
+@PART[USWaterWedge]:NEEDS[UniversalStorage2&!IFILS] // base
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USWaterWedge]:NEEDS[UniversalStorage2&!IFILS&TacLifeSupport|Kerbalism] // if using a life support mod that requires water as a primary need
 {
     %VABORGANIZER
     {
         %organizerSubcategory = LifeSupport
     }
 }
-@PART[USCarbonDioxideWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism]
+@PART[USEVAX]:NEEDS[UniversalStorage2&KIS&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS] // these life support mods (except KIS) are not required for the part to show up in-game
 {
     %VABORGANIZER
     {
         %organizerSubcategory = LifeSupport
-    }
-}
-@PART[USGreyWaterWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|USILifeSupport]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = LifeSupport
-    }
-}
-@PART[USSolidWasteWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = LifeSupport
-    }
-}
-@PART[USEVAX]:NEEDS[UniversalStorage2&KIS]
-{
-    %VABORGANIZER
-    {
-        %organizerSubcategory = cargoContainers
     }
 }


### PR DESCRIPTION
- Adds a new `resourceUtilization` subcategory to be used for ISRUs and parts used towards life support resource generation and waste by it.
- Updates `LifeSuppport` subcategory to be used for direct needs requirements added by life support mods (food, oxygen, rad protection, water, etc.).
- Updates Universal Storage 2 patch to incorporate these changes and adds explained conditions.