### PR TITLE
Adds compatibility to DeepFreeze Continued and Global Construction

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/DeepFreezeContinued/DeepFreeze_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/DeepFreezeContinued/DeepFreeze_VABO.cfg
@@ -1,0 +1,18 @@
+// Config for DeepFreeze Continued Parts
+
+/// Utility
+///--------------
+@PART[GlykerolTankRadial]:NEEDS[DeepFreeze]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[CRY-0300Freezer|CRY-0300RFreezer|CRY-1300Freezer|CRY-2300Freezer]:NEEDS[DeepFreeze]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = crewHabitation
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/GlobalConstruction/GlobalConstruction_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/GlobalConstruction/GlobalConstruction_VABO.cfg
@@ -1,0 +1,48 @@
+// Config for [mod name] Parts
+
+/// Command
+/// -------------
+@PART[SpaceCrane]:NEEDS[GroundConstruction]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = probes
+    }
+}
+@PART[GroundAssemblyLine|InlineGroundWorkshop|MobileWorkshop|OrbitalAssemblyLine|OrbitalWorkshop]:NEEDS[GroundConstruction]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fabrication
+    }
+}
+
+/// Coupling
+/// -------------
+@PART[MagneticFork]:NEEDS[GroundConstruction]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = grapples
+    }
+}
+
+/// Payload
+/// -------------
+@PART[DIYKit|OrbitalKitContainer2|OrbitalKitContainer]:NEEDS[GroundConstruction]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fabrication
+    }
+}
+
+/// Utility
+/// -------------
+@PART[OrbitalAssemblySpace|OrbitalWorkshop]:NEEDS[GroundConstruction]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fabrication
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -6,10 +6,11 @@ Localization
     #LOC_VABOrganizer_Subcategory_DataCoreChips = DataCore Chips
     // Shared
     #LOC_VABOrganizer_Subcategory_Cores = Cores
-    #LOC_VABOrganizer_Subcategory_resourceUtilization = Resource Utilization
+    #LOC_VABOrganizer_Subcategory_fabrication = Fabrication
     #LOC_VABOrganizer_Subcategory_LifeSupport = Life Support
+    #LOC_VABOrganizer_Subcategory_resourceUtilization = Resource Utilization
     #LOC_VABOrganizer_Subcategory_ScanMulti = Multispectral Scanners
     #LOC_VABOrganizer_Subcategory_ScanAltimetry = Altimetry Scanners
-    #LOC_VABOrganizer_Subcategory_ScanVisual = Visual Scanners    
+    #LOC_VABOrganizer_Subcategory_ScanVisual = Visual Scanners
   }
 }

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -1,19 +1,19 @@
 // Used by ChromaWorks, USII
 ORGANIZERSUBCATEGORY
 {
-    name = cores
-    Label = #LOC_VABOrganizer_Subcategory_Cores    // Cores
-    Priority = 5
-    CategoryPriority = 25
+  name = cores
+  Label = #LOC_VABOrganizer_Subcategory_Cores    // Cores
+  Priority = 5
+  CategoryPriority = 25
 }
-// Used by USII, USI_LifeSupport, DeepFreeze
+// Used by GlobalConstruction
 ORGANIZERSUBCATEGORY
 {
-  // currently for ISRUs, parts used towards life support
-  name = resourceUtilization
-  Label = #LOC_VABOrganizer_Subcategory_resourceUtilization   // Resource Utilization
-  Priority = 82
-  CategoryPriority = 70
+  // for construction and production of other parts and use therein
+	name = fabrication
+	Label = #LOC_VABOrganizer_Subcategory_fabrication // Fabrication
+	Priority = 78
+	CategoryPriority = 70
 }
 // Used by Kerbalism, USII, USI_LifeSupport
 ORGANIZERSUBCATEGORY
@@ -22,6 +22,15 @@ ORGANIZERSUBCATEGORY
   name = LifeSupport
   Label = #LOC_VABOrganizer_Subcategory_LifeSupport    // Life Support
   Priority = 83
+  CategoryPriority = 70
+}
+// Used by USII, USI_LifeSupport, DeepFreeze
+ORGANIZERSUBCATEGORY
+{
+  // currently for ISRUs, parts and ingredients used towards producing other resources
+  name = resourceUtilization
+  Label = #LOC_VABOrganizer_Subcategory_resourceUtilization   // Resource Utilization
+  Priority = 81
   CategoryPriority = 70
 }
 // Used by SCANsat, OrbitalScience

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -6,7 +6,7 @@ ORGANIZERSUBCATEGORY
     Priority = 5
     CategoryPriority = 25
 }
-// Used by USII
+// Used by USII, USI_LifeSupport, DeepFreeze
 ORGANIZERSUBCATEGORY
 {
   // currently for ISRUs, parts used towards life support
@@ -15,7 +15,7 @@ ORGANIZERSUBCATEGORY
   Priority = 82
   CategoryPriority = 70
 }
-// Used by Kerbalism, USII
+// Used by Kerbalism, USII, USI_LifeSupport
 ORGANIZERSUBCATEGORY
 {
   // for direct needs requirements to live by life support mods (food, oxygen, rad-x, water, etc.)


### PR DESCRIPTION
- Assigns subcategories to parts in DeepFreeze Continued.
- Adds new subcategory (`fabrication`) for use with parts involved in the construction and production of other parts and use therein.
- Assigns subcategories to parts in Global Construction.
- Refines explanation of when to use the `resourceUtilization` subcategory and its location order.