### PR TITLE
Adds compatibility to Kerbal Actuators and localization edits

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/KerbalActuators/KerbalActuators_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/KerbalActuators/KerbalActuators_VABO.cfg
@@ -1,0 +1,11 @@
+// Config for Kerbal Actuators Parts
+
+/// Utility
+/// -------------
+@PART[wbiSampleArm|wbiSampleCrane]:NEEDS[KerbalActuators]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = roboticArms
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -3,14 +3,15 @@ Localization
   en-us
   {
     // ChromaWorks
-    #LOC_VABOrganizer_Subcategory_DataCoreChips = DataCore Chips
+    #LOC_VABOSheepdog_Subcategory_DataCoreChips = DataCore Chips
     // Shared
-    #LOC_VABOrganizer_Subcategory_Cores = Cores
-    #LOC_VABOrganizer_Subcategory_fabrication = Fabrication
-    #LOC_VABOrganizer_Subcategory_LifeSupport = Life Support
-    #LOC_VABOrganizer_Subcategory_resourceUtilization = Resource Utilization
-    #LOC_VABOrganizer_Subcategory_ScanMulti = Multispectral Scanners
-    #LOC_VABOrganizer_Subcategory_ScanAltimetry = Altimetry Scanners
-    #LOC_VABOrganizer_Subcategory_ScanVisual = Visual Scanners
+    #LOC_VABOSheepdog_Subcategory_Cores = Cores
+    #LOC_VABOSheepdog_Subcategory_fabrication = Fabrication
+    #LOC_VABOSheepdog_Subcategory_LifeSupport = Life Support
+    #LOC_VABOSheepdog_Subcategory_resourceUtilization = Resource Utilization
+    #LOC_VABOSheepdog_Subcategory_roboticArms = Manipulator Arms
+    #LOC_VABOSheepdog_Subcategory_ScanMulti = Multispectral Scanners
+    #LOC_VABOSheepdog_Subcategory_ScanAltimetry = Altimetry Scanners
+    #LOC_VABOSheepdog_Subcategory_ScanVisual = Visual Scanners
   }
 }

--- a/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/OrbitalScience/DMagicOrbitalScience_VABO.cfg
@@ -26,7 +26,7 @@
         %organizerSubcategory = science
     }
 }
-@PART[dmbioDrill]:AFTER[VABOrganizer]:NEEDS[DMagicOrbitalScience] // VAB Organizer moves it into 'resources' subcategory since it has 'Drill' in its name
+@PART[dmbioDrill]:FOR[VABOrganizer-Sheepdog]:NEEDS[DMagicOrbitalScience] // VAB Organizer moves it into 'resources' subcategory since it has 'Drill' in its name
 {
     %VABORGANIZER
     {

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -2,16 +2,16 @@
 ORGANIZERSUBCATEGORY
 {
   name = cores
-  Label = #LOC_VABOrganizer_Subcategory_Cores    // Cores
+  Label = #LOC_VABOSheepdog_Subcategory_Cores    // Cores
   Priority = 5
   CategoryPriority = 25
 }
-// Used by GlobalConstruction
+// Used by GlobalConstruction, USI_Konstruction
 ORGANIZERSUBCATEGORY
 {
   // for construction and production of other parts and use therein
 	name = fabrication
-	Label = #LOC_VABOrganizer_Subcategory_fabrication // Fabrication
+	Label = #LOC_VABOSheepdog_Subcategory_fabrication   // Fabrication
 	Priority = 78
 	CategoryPriority = 70
 }
@@ -20,7 +20,7 @@ ORGANIZERSUBCATEGORY
 {
   // for direct needs requirements to live by life support mods (food, oxygen, rad-x, water, etc.)
   name = LifeSupport
-  Label = #LOC_VABOrganizer_Subcategory_LifeSupport    // Life Support
+  Label = #LOC_VABOSheepdog_Subcategory_LifeSupport    // Life Support
   Priority = 83
   CategoryPriority = 70
 }
@@ -29,16 +29,25 @@ ORGANIZERSUBCATEGORY
 {
   // currently for ISRUs, parts and ingredients used towards producing other resources
   name = resourceUtilization
-  Label = #LOC_VABOrganizer_Subcategory_resourceUtilization   // Resource Utilization
+  Label = #LOC_VABOSheepdog_Subcategory_resourceUtilization   // Resource Utilization
   Priority = 81
   CategoryPriority = 70
+}
+// Used by KerbalActuators, USI_Konstruction
+ORGANIZERSUBCATEGORY
+{
+  // for robotic arms and manipulators
+  name = roboticArms
+  Label = #LOC_VABOSheepdog_Subcategory_roboticArms   // Manipulator Arms
+  Priority = 30
+  CategoryPriority = 25
 }
 // Used by SCANsat, OrbitalScience
 ORGANIZERSUBCATEGORY
 {
   // for scanners like Multispectral that do biome and more types (multi)
   name = ScanMulti
-  Label = #LOC_VABOrganizer_Subcategory_ScanMulti    // Multispectral Scanners
+  Label = #LOC_VABOSheepdog_Subcategory_ScanMulti    // Multispectral Scanners
   Priority = 27
   CategoryPriority = 65
 }
@@ -47,7 +56,7 @@ ORGANIZERSUBCATEGORY
 {
   // for primarily both LoRes and HiRes Altimetry scanners (radar and sar)
   name = ScanAltimetry
-  Label = #LOC_VABOrganizer_Subcategory_ScanAltimetry    // Altimetry Scanners
+  Label = #LOC_VABOSheepdog_Subcategory_ScanAltimetry    // Altimetry Scanners
   Priority = 28
   CategoryPriority = 65
 }
@@ -56,7 +65,7 @@ ORGANIZERSUBCATEGORY
 {
   // for primarily both BTDT and Visual scanners (btdt and recon)
   name = ScanVisual
-  Label = #LOC_VABOrganizer_Subcategory_ScanVisual   // Visual Scanners
+  Label = #LOC_VABOSheepdog_Subcategory_ScanVisual   // Visual Scanners
   Priority = 29
   CategoryPriority = 65
 }


### PR DESCRIPTION
- Creates a new subcategory (`roboticArms`) for robotic arms and manipulators.
- Assigns that subcategory to parts in Kerbal Actuators.
- Switches out _VABOrganizer_ for _VABOSheepdog_ in localizations for consistency and compatibility.
- Small edit in DMagicOrbitalScience_VABO.cfg for better compatibility.