### PR TITLE
Minor Changes

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/ChromaWorks/CW-Subcatagory.cfg
+++ b/GameData/VABOrganizer-Sheepdog/ChromaWorks/CW-Subcatagory.cfg
@@ -1,7 +1,0 @@
-ORGANIZERSUBCATEGORY:NEEDS[ChromaWorks]
-{
-  name = dataCoreChips
-  Label = #LOC_VABOrganizer_Subcategory_DataCoreChips   // DataCore Chips
-  Priority = 27
-  CategoryPriority = 65
-}

--- a/GameData/VABOrganizer-Sheepdog/DeepFreezeContinued/DeepFreeze_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/DeepFreezeContinued/DeepFreeze_VABO.cfg
@@ -13,6 +13,6 @@
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = crewHabitation
+        %organizerSubcategory = crewTransport
     }
 }

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
@@ -1,3 +1,12 @@
+// ChromaWorks
+ORGANIZERSUBCATEGORY:NEEDS[ChromaWorks]
+{
+  name = dataCoreChips
+  Label = #LOC_VABOSheepdog_Subcategory_DataCoreChips   // DataCore Chips
+  Priority = 27
+  CategoryPriority = 65
+}
+
 // Umbra Space Industries (USI)
 ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/SrvPack|UmbraSpaceIndustries/SubPack]
 {

--- a/GameData/VABOrganizer-Sheepdog/USII/USIIVABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/USII/USIIVABO.cfg
@@ -145,11 +145,18 @@
         %organizerSubcategory = resourceUtilization
     }
 }
-@PART[USWaterPurifier]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|USILifeSupport|IFILS]
+@PART[USWaterPurifier]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism|SnacksUtils|IFILS]
 {
     %VABORGANIZER
     {
         %organizerSubcategory = resourceUtilization
+    }
+}
+@PART[USWaterPurifier]:NEEDS[UniversalStorage2&USILifeSupport]  // Instead, extends how long life support lasts when using USI Life Support
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = LifeSupport
     }
 }
 @PART[USCarbonDioxideWedge]:NEEDS[UniversalStorage2&TacLifeSupport|Kerbalism]


### PR DESCRIPTION
- Switches Freezers to `crewTransport` from `crewHabitation` in DeepFreeze Cont.
- Switches `USWaterPurifier` part subcategory assignment to `LifeSupport` when using USI Life Support in US2.
- Moves the separate file for a ChromaWorks subcategory into the ModDependent_subcategories file.