### PR TITLE
Compatibility to SquiggsySpaceResearch-MicroSat

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/SSR_MicroSat/MicroSat_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/SSR_MicroSat/MicroSat_VABO.cfg
@@ -1,0 +1,137 @@
+// Config for MicroSat Parts
+
+/// Command
+/// -------------
+@PART[MicroSat]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = probes
+    }
+}
+
+/// Communication
+/// -------------
+@PART[FixedDish01]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = relay
+    }
+}
+@PART[foldedDipole|foldingDish01]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = direct
+    }
+}
+
+/// Coupling
+/// -------------
+@PART[35decoupler|625decoupler]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = decouplers
+    }
+}
+
+/// Electrical
+/// -------------
+@PART[MICROBATSQUARE]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = batteries
+    }
+}
+@PART[microCapacitor]:NEEDS[SquiggsySpaceResearch&NearFutureElectrical]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = capacitors
+    }
+}
+@PART[micrortg]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rtgs
+    }
+}
+@PART[microSolarUnshielded]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = solarPanels
+    }
+}
+
+/// Engines
+/// -------------
+@PART[upperStageEngine|microsatEngine]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfoEngines
+    }
+}
+@PART[solidBoosterMini]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = solidEngines
+    }
+}
+@PART[microIon]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = ionEngines
+    }
+}
+
+/// Fuel
+/// -------------
+@PART[625liquidFuel|microlqdfuel]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+@PART[microXenon|radialXenonmicro]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = xenon
+    }
+}
+@PART[microArgon]:NEEDS[SquiggsySpaceResearch&NearFuturePropulsion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = argon
+    }
+}
+
+/// Payload
+/// -------------
+@PART[fairingSize0]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fairings
+    }
+}
+
+/// Science
+/// -------------
+@PART[MicroScanner]:NEEDS[SquiggsySpaceResearch]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = resourceScanners
+    }
+}


### PR DESCRIPTION
- Assigns subcategories to parts in [Squiggsy Space Research 0.35m MicroSat and Airlaunch Vehicle](https://forum.kerbalspaceprogram.com/topic/173508-112x-the-035m-ssr-microsat-and-airlaunch-vehicle/)

---
I should note that I submitted a [pull request](https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts/pull/8) to add this on the [mod's primary GitHub repository](https://github.com/linuxgurugamer/MicroSat_0.35m_Probe_Parts), However, it has sat without a response for the past three weeks at the time of typing this. Unsure of when and if it will be added, I am submitting it here. This way users may have easy access to the support rather than possibly be unware of it. If it does eventually get added and an update released, I will submit for it to be removed from here. I otherwise leave it up to you whether you want to hold off longer, have other suggestions/reservations, or approve of adding this.