### PR TITLE
Adds compatibility for HabTech Robotics, MechJeb 2, and SmartParts

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -12,6 +12,7 @@ Localization
         #LOC_VABOSheepdog_Subcategory_fabrication = Fabrication
         #LOC_VABOSheepdog_Subcategory_fluidContainers = Fluid Containers
         #LOC_VABOSheepdog_Subcategory_LifeSupport = Life Support
+        #LOC_VABOSheepdog_Subcategory_PLC = PLC
         #LOC_VABOSheepdog_Subcategory_resourceUtilization = Resource Utilization  // Resource Utilisation
         #LOC_VABOSheepdog_Subcategory_roboticArms = Manipulator Arms
         #LOC_VABOSheepdog_Subcategory_ScanMulti = Multispectral Scanners

--- a/GameData/VABOrganizer-Sheepdog/MechJeb2/MechJeb2_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/MechJeb2/MechJeb2_VABO.cfg
@@ -1,0 +1,11 @@
+// Config for MechJeb 2 Parts
+
+/// Command
+/// -------------
+@PART[mumech_MJ2_AR202*]:NEEDS[MechJeb2]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = PLC
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/PatchManager/PM_htRobotics.cfg
+++ b/GameData/VABOrganizer-Sheepdog/PatchManager/PM_htRobotics.cfg
@@ -1,0 +1,23 @@
+PatchManager
+{
+    modName = VABOrganizer-Sheepdog
+    patchName = VABO-SD_htRobotics_Bulkhead
+    srcPath = VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Bulkhead.cfg
+    shortDescr = HTRobotics Bulkhead
+    longDescr = Sets the bulkhead profile to size00 (0.3125m) for parts in HabTech Robotics.
+    dependencies = htRobotics
+    author = Adventurer13
+    installedWithMod = false
+}
+
+PatchManager
+{
+    modName = VABOrganizer-Sheepdog
+    patchName = VABO-SD_htRobotics_Category
+    srcPath = VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Category.cfg
+    shortDescr = HTRobotics Category Switch
+    longDescr = Switches the category the "Structural Boom" parts appear in from Structural to Robotics in HabTech Robotics.
+    dependencies = htRobotics
+    author = Adventurer13
+    installedWithMod = false
+}

--- a/GameData/VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Bulkhead.cfg
+++ b/GameData/VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Bulkhead.cfg
@@ -1,0 +1,9 @@
+// Modified bulkhead profiles for HabTech Robotics
+@PART[ht_canadarm2_boom|ht_C1_boom|ht_JEM_RMS_boom|ht_canadarm2_servo|ht_JEM_RMS_servo|ht_C1_elbow|ht_C1_pitch|ht_C1_rotator|ht_grappleFixtureKibo|ht_grappleFixture|ht_PDGF|ht_C1_LEE|ht_canadarm2_LEE]:NEEDS[htRobotics]
+{
+    @bulkheadProfiles = size00
+}
+@PART[ht_grappleFixtureKibo|ht_grappleFixture|ht_PDGF]:NEEDS[htRobotics]
+{
+    @bulkheadProfiles = size00, srf
+}

--- a/GameData/VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Category.cfg
+++ b/GameData/VABOrganizer-Sheepdog/PatchManager/PluginData/VABO-SD_htRobotics_Category.cfg
@@ -1,0 +1,5 @@
+// Category switches for HabTech Robotics boom parts
+@PART[ht_canadarm2_boom|ht_C1_boom|ht_JEM_RMS_boom]:NEEDS[htRobotics]
+{
+    %category = Robotics    // default: Structural
+}

--- a/GameData/VABOrganizer-Sheepdog/SmartParts/SmartParts_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/SmartParts/SmartParts_VABO.cfg
@@ -1,0 +1,11 @@
+// Config for Smart Parts Continued Parts
+
+/// Command
+/// -------------
+@PART[kb-fuel-breaker*|FuelController|km_smart*|km_prox_sensor|km_valve|km_valve2]:NEEDS[SmartParts]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = PLC
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -33,6 +33,15 @@ ORGANIZERSUBCATEGORY
     Priority = 83
     CategoryPriority = 70
 }
+// Used by MechJeb2, SmartParts
+ORGANIZERSUBCATEGORY
+{
+    // for programmable logic controllers and control systems
+    name = PLC
+    Label = #LOC_VABOSheepdog_Subcategory_PLC    // PLC
+    Priority = 35
+    CategoryPriority = 15
+}
 // Used by USII, DeepFreeze, USI_LifeSupport, USI_ExplorationPack, KPBS
 ORGANIZERSUBCATEGORY
 {

--- a/GameData/VABOrganizer-Sheepdog/htRobotics/htRobotics_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/htRobotics/htRobotics_VABO.cfg
@@ -1,0 +1,31 @@
+// Config for HabTech Robotics Parts
+
+/// Coupling
+/// -------------
+@PART[ht_grappleFixtureKibo|ht_grappleFixture|ht_PDGF|ht_C1_LEE|ht_canadarm2_LEE]:NEEDS[htRobotics]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = dockingPorts
+    }
+}
+
+/// Robotics
+/// -------------
+@PART[ht_canadarm2_servo|ht_JEM_RMS_servo|ht_C1_elbow|ht_C1_pitch|ht_C1_rotator]:NEEDS[htRobotics]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = hinges
+    }
+}
+
+/// Structural
+/// -------------
+@PART[ht_canadarm2_boom|ht_C1_boom|ht_JEM_RMS_boom]:NEEDS[htRobotics]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = tubes
+    }
+}


### PR DESCRIPTION
- Adds a new `PLC` subcategory to be used for programmable logic controllers and control systems.
- Assigns subcategory to parts in [MechJeb 2](https://github.com/MuMech/MechJeb2).
- Assigns subcategory to parts in [Smart Parts Continued](https://github.com/linuxgurugamer/KerbalSmartParts).
---
- Assigns subcategories to parts in [htRobotics](https://github.com/benjee10/htRobotics).
- Adds optional separate patches for htRobotics when using [PatchManager](https://github.com/linuxgurugamer/PatchManager) for 
   - assigning the bulkhead profile to size00, **[0.3125m]**, for parts.
   - switching the category for the "Structural Boom" parts to Robotics.