### PR TITLE
USI ExpPack Refinement and Kerbal Engineer compat

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/KerbalEngineer/KerbalEngineer_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/KerbalEngineer/KerbalEngineer_VABO.cfg
@@ -1,0 +1,9 @@
+// Config for Kerbal Engineer Parts
+
+@PART[Engineer7500|EngineerChip]:NEEDS[KerbalEngineer]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = expanBoards
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -10,6 +10,7 @@ Localization
         #LOC_VABOSheepdog_Subcategory_USI_Logistics = Logistics
         /// Shared
         #LOC_VABOSheepdog_Subcategory_Cores = Cores
+        #LOC_VABOSheepdog_Subcategory_expanBoards = Expansion Boards
         #LOC_VABOSheepdog_Subcategory_fabrication = Fabrication
         #LOC_VABOSheepdog_Subcategory_fluidContainers = Fluid Containers
         #LOC_VABOSheepdog_Subcategory_LifeSupport = Life Support

--- a/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Localization/en-us.cfg
@@ -5,7 +5,8 @@ Localization
         // Subcategories
         /// Mod-dependent
         #LOC_VABOSheepdog_Subcategory_DataCoreChips = DataCore Chips
-        #LOC_VABOSheepdog_Subcategory_USI_fluidBladders = Fluid Bladders
+        #LOC_VABOSheepdog_Subcategory_airbagsParachutes = Airbags and Parachutes
+        #LOC_VABOSheepdog_Subcategory_buoyancy = Buoyancy
         #LOC_VABOSheepdog_Subcategory_USI_Logistics = Logistics
         /// Shared
         #LOC_VABOSheepdog_Subcategory_Cores = Cores

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Adopted_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Adopted_subcategories.cfg
@@ -5,7 +5,7 @@ ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
     name = baseFrames
     Label = #LOC_VABOSheepdog_subcategory_baseFrames  // Base Frames
     Priority = 35
-    CategoryPriority = 45
+    CategoryPriority = 45   // Ground
 }
 ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
 {
@@ -13,7 +13,7 @@ ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
     name = crewUtility
     Label = #LOC_VABOSheepdog_subcategory_crewUtility   // Station Utility
     Priority = 88
-    CategoryPriority = 70
+    CategoryPriority = 70   // Utility
 }
 ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
 {
@@ -21,7 +21,7 @@ ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
     name = crewTubes
     Label = #LOC_VABOSheepdog_subcategory_crewTubes   // Station Connectors
     Priority = 88
-    CategoryPriority = 50
+    CategoryPriority = 20   // Structural
 }
 ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
 {
@@ -29,7 +29,7 @@ ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
     name = crewAdapters
     Label = #LOC_VABOSheepdog_subcategory_crewAdapters  // Station Adapters
     Priority = 15
-    CategoryPriority = 20
+    CategoryPriority = 20   // Structural
 }
 ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
 {
@@ -37,5 +37,5 @@ ORGANIZERSUBCATEGORY:NEEDS[!StationPartsExpansionRedux]
     name = crewHubs
     Label = #LOC_VABOSheepdog_subcategory_crewHubs    // Station Hubs
     Priority = 110
-    CategoryPriority = 20
+    CategoryPriority = 20   // Structural
 }

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
@@ -2,17 +2,21 @@
 ORGANIZERSUBCATEGORY:NEEDS[ChromaWorks]
 {
     name = dataCoreChips
-    Label = #LOC_VABOSheepdog_Subcategory_DataCoreChips   // DataCore Chips
+    Label = #LOC_VABOSheepdog_Subcategory_DataCoreChips         // DataCore Chips
     Priority = 27
     CategoryPriority = 65
 }
 
 // Umbra Space Industries (USI)
+@ORGANIZERSUBCATEGORY[parachutes]:AFTER[VABOrganizer]:NEEDS[UmbraSpaceIndustries/SrvPack]
+{
+    @Label = #LOC_VABOSheepdog_Subcategory_airbagsParachutes    // Airbags and Parachutes
+}
 ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/SrvPack|UmbraSpaceIndustries/SubPack]
 {
-    // for liquid and gas inflatable bladders (airbags, ballast, floats, etc.) in SrvPack and SubPack of USI_ExplorationPack
-    name = fluidBladders
-    Label = #LOC_VABOSheepdog_Subcategory_USI_fluidBladders  // Fluid Bladders
+    // for parts designed with buoyancy (ballast, floats, etc.) in SrvPack and SubPack of USI_ExplorationPack
+    name = buoyancy
+    Label = #LOC_VABOSheepdog_Subcategory_buoyancy              // Buoyancy
     Priority = 7
     CategoryPriority = 70
 }
@@ -20,7 +24,7 @@ ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/MKS|UmbraSpaceIndustries/WOLF]
 {
     // For the parts related to the operation of logistics in MKS and WOLF of USI_KolonizationSystems
     name = USI_Logistics
-    Label = #LOC_VABOSheepdog_Subcategory_USI_Logistics    // Logistics
+    Label = #LOC_VABOSheepdog_Subcategory_USI_Logistics         // Logistics
     Priority = 28
     CategoryPriority = 35
 }

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/ModDependent_subcategories.cfg
@@ -4,7 +4,7 @@ ORGANIZERSUBCATEGORY:NEEDS[ChromaWorks]
     name = dataCoreChips
     Label = #LOC_VABOSheepdog_Subcategory_DataCoreChips         // DataCore Chips
     Priority = 27
-    CategoryPriority = 65
+    CategoryPriority = 65   // Science
 }
 
 // Umbra Space Industries (USI)
@@ -18,7 +18,7 @@ ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/SrvPack|UmbraSpaceIndustries/Sub
     name = buoyancy
     Label = #LOC_VABOSheepdog_Subcategory_buoyancy              // Buoyancy
     Priority = 7
-    CategoryPriority = 70
+    CategoryPriority = 70   // Utility
 }
 ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/MKS|UmbraSpaceIndustries/WOLF]
 {
@@ -26,5 +26,5 @@ ORGANIZERSUBCATEGORY:NEEDS[UmbraSpaceIndustries/MKS|UmbraSpaceIndustries/WOLF]
     name = USI_Logistics
     Label = #LOC_VABOSheepdog_Subcategory_USI_Logistics         // Logistics
     Priority = 28
-    CategoryPriority = 35
+    CategoryPriority = 35   // Payload
 }

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -6,6 +6,15 @@ ORGANIZERSUBCATEGORY
     Priority = 8
     CategoryPriority = 35   // Payload
 }
+// Used by KerbalEngineer
+ORGANIZERSUBCATEGORY
+{
+    // for printed circuit boards and similar that provide additional features and capabilities
+    name = expanBoards
+    Label = #LOC_VABOSheepdog_Subcategory_expanBoards   // Expansion Boards
+    Priority = 895
+    CategoryPriority = 15   // Command and Control
+}
 // Used by GlobalConstruction, USI_Konstruction, USI_KolonizationSystems, KPBS
 ORGANIZERSUBCATEGORY
 {

--- a/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
+++ b/GameData/VABOrganizer-Sheepdog/Standalone-SubCatagories/Shared_subcategories.cfg
@@ -3,8 +3,8 @@ ORGANIZERSUBCATEGORY
 {
     name = cores
     Label = #LOC_VABOSheepdog_Subcategory_Cores    // Cores
-    Priority = 5
-    CategoryPriority = 25
+    Priority = 8
+    CategoryPriority = 35   // Payload
 }
 // Used by GlobalConstruction, USI_Konstruction, USI_KolonizationSystems, KPBS
 ORGANIZERSUBCATEGORY
@@ -13,7 +13,7 @@ ORGANIZERSUBCATEGORY
     name = fabrication
     Label = #LOC_VABOSheepdog_Subcategory_fabrication   // Fabrication
     Priority = 78
-    CategoryPriority = 70
+    CategoryPriority = 70   // Utility
 }
 // Used by USI_Core, USI_KolonizationSystems
 ORGANIZERSUBCATEGORY
@@ -22,7 +22,7 @@ ORGANIZERSUBCATEGORY
     name = fluidContainers
     Label = #LOC_VABOSheepdog_Subcategory_fluidContainers   // Fluid Containers
     Priority = 32
-    CategoryPriority = 35
+    CategoryPriority = 35   // Payload
 }
 // Used by Kerbalism, USII, USI_LifeSupport, USI_ExplorationPack, USI_KolonizationSystems, KPBS
 ORGANIZERSUBCATEGORY
@@ -31,7 +31,7 @@ ORGANIZERSUBCATEGORY
     name = LifeSupport
     Label = #LOC_VABOSheepdog_Subcategory_LifeSupport    // Life Support
     Priority = 83
-    CategoryPriority = 70
+    CategoryPriority = 70   // Utility
 }
 // Used by MechJeb2, SmartParts
 ORGANIZERSUBCATEGORY
@@ -40,7 +40,7 @@ ORGANIZERSUBCATEGORY
     name = PLC
     Label = #LOC_VABOSheepdog_Subcategory_PLC    // PLC
     Priority = 35
-    CategoryPriority = 15
+    CategoryPriority = 15   // Command and Control
 }
 // Used by USII, DeepFreeze, USI_LifeSupport, USI_ExplorationPack, KPBS
 ORGANIZERSUBCATEGORY
@@ -49,7 +49,7 @@ ORGANIZERSUBCATEGORY
     name = resourceUtilization
     Label = #LOC_VABOSheepdog_Subcategory_resourceUtilization   // Resource Utilization
     Priority = 81
-    CategoryPriority = 70
+    CategoryPriority = 70   // Utility
 }
 // Used by KerbalActuators, USI_Konstruction
 ORGANIZERSUBCATEGORY
@@ -58,7 +58,7 @@ ORGANIZERSUBCATEGORY
     name = roboticArms
     Label = #LOC_VABOSheepdog_Subcategory_roboticArms   // Manipulator Arms
     Priority = 30
-    CategoryPriority = 25
+    CategoryPriority = 25   // Robotics
 }
 // Used by SCANsat, OrbitalScience
 ORGANIZERSUBCATEGORY
@@ -67,7 +67,7 @@ ORGANIZERSUBCATEGORY
     name = ScanMulti
     Label = #LOC_VABOSheepdog_Subcategory_ScanMulti    // Multispectral Scanners
     Priority = 27
-    CategoryPriority = 65
+    CategoryPriority = 65   // Science
 }
 // Used by SCANsat
 ORGANIZERSUBCATEGORY
@@ -76,7 +76,7 @@ ORGANIZERSUBCATEGORY
     name = ScanAltimetry
     Label = #LOC_VABOSheepdog_Subcategory_ScanAltimetry    // Altimetry Scanners
     Priority = 28
-    CategoryPriority = 65
+    CategoryPriority = 65   // Science
 }
 // Used by SCANsat, LRTR, OrbitalScience
 ORGANIZERSUBCATEGORY
@@ -85,5 +85,5 @@ ORGANIZERSUBCATEGORY
     name = ScanVisual
     Label = #LOC_VABOSheepdog_Subcategory_ScanVisual   // Visual Scanners
     Priority = 29
-    CategoryPriority = 65
+    CategoryPriority = 65   // Science
 }

--- a/GameData/VABOrganizer-Sheepdog/UmbraSpaceIndustries/USI_ExplorationPack_VABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/UmbraSpaceIndustries/USI_ExplorationPack_VABO.cfg
@@ -201,17 +201,17 @@
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = fluidBladders
+        %organizerSubcategory = buoyancy
     }
 }
-@PART[USI_Airbag_Single_0?|USI_Radial_Float_*|USI_Inline_Float_*]:NEEDS[UmbraSpaceIndustries/SrvPack]
+@PART[USI_Radial_Float_*|USI_Inline_Float_*]:NEEDS[UmbraSpaceIndustries/SrvPack]
 {
     %VABORGANIZER
     {
-        %organizerSubcategory = fluidBladders
+        %organizerSubcategory = buoyancy
     }
 }
-@PART[DERP_RadialPara]:NEEDS[UmbraSpaceIndustries/SrvPack]
+@PART[DERP_RadialPara|USI_Airbag_Single_0?]:NEEDS[UmbraSpaceIndustries/SrvPack]
 {
     %VABORGANIZER
     {


### PR DESCRIPTION
- Replaces the *Fluid Bladders* with *Buoyancy* subcategory. Still dependent upon 'SrvPack' or 'SubPack' of USI Exploration Pack.
- Renames *Parachutes* in VAB Organizer to *Airbags and Parachutes* only when using 'SrvPack' of USI Exploration Pack.


Having played with these changes on my own for a bit, I think this is a better solution than what I had created before. It keeps a separation between parts for landing and when in liquid, which Fluid Bladders did not do. I also was not satisfied with the previous name. Grouping airbags and parachutes, rather than keeping separate, makes sense since they both handle the purpose of landing a craft.

---
- Adds information for category priority to subcategories.
   - Adjusts priorities for the cores subcategory.
- Adds *Expansion Boards* (`expanBoards`) subcategory for PCBs and similar that provide additional features and capabilities.
   - Assigns parts from [Kerbal Engineer Redux](https://github.com/jrbudda/KerbalEngineer) to it.