### PR TITLE
Add AirplanePlus missing parts + KW rocketry + Mk3Expansion

### DIFF
--- a/GameData/VABOrganizer-Sheepdog/AirplanePlus/AirplanePlusVABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/AirplanePlus/AirplanePlusVABO.cfg
@@ -1,4 +1,12 @@
 // Aero
+@PART[minishortboom,miniboom,shortboom,shortboomb,s1p5booma,s1p5boomashort,s1p5boomb,s1p5boombshort,size2taila,size2tailashort,size2tailb,size2tailbshort,mk3s0booma,mk3s0boomb,mk3s1booma,mk3s1boomb]:NEEDS[AirplanePlus]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = noses
+    }
+}
+
 @PART[smallwingConnector?|smallwingConnectortip|hangle?|fatwing?|bigwing|vangle?|]:NEEDS[AirplanePlus]
 {
 	%VABORGANIZER
@@ -119,6 +127,14 @@
 
 
 // Engines
+@PART[S1APU,S1p5APU,S2APU]:NEEDS[AirplanePlus]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = jetEngines
+    }
+}
+
 @PART[cf34|cfm56|f5jet|raptorjet]:NEEDS[AirplanePlus]
 {
 	%VABORGANIZER
@@ -150,6 +166,14 @@
 
 
 // Structural
+@PART[Mk1SlantStructural,Mk1JuniorStructural,s1p5hull,s1p5hulllong,S2Hull,S2Structural]:NEEDS[AirplanePlus]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = tubes
+    }
+}
+
 @PART[mk3s1p5-s1p5]:NEEDS[AirplanePlus]
 {
 	%VABORGANIZER

--- a/GameData/VABOrganizer-Sheepdog/KWRocketry/KWRocketryVABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/KWRocketry/KWRocketryVABO.cfg
@@ -1,0 +1,149 @@
+/////////////////////////////////////////////////////
+// KW Rocketry
+/////////////////////////////////////////////////////
+
+
+// FUEL
+@PART[KW1mtankPancake,KW1mtankL0_5,KW1mtankL1,KW1mtankL2,KW1mtankL4,KW2Sidetank,KW2mtankPancake,KW2mtankL0_5,KW2mtankL1,KW2mtankL2,KW2mtankL4,KW2mtankL4A]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+
+@PART[KW3Sidetank,KW3mtankPancake,KW3mtankL0_5,KW3mtankL1,KW3mtankL2,KW3mtankL4,KW3mtankL4A,KW5mtankL05,KW5mtankL1_5,KW5mtankL3_5]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+
+@PART[KWFuelAdapter2x1,KWFuelAdapter2x1S,KWFuelAdapter3x1,KWFuelAdapter3x1S,KWFuelAdapter3x2,KWFuelAdapter3x2S,KWFuelAdapter5x2,KWFuelAdapter5x3]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+
+@PART[KW1mRCSfuel,KW2mRCSfuel,KW3mRCSfuel]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = monoprop
+    }
+}
+
+// ENGINES
+@PART[KW1mengineMaverick1D,KW1mengineVestaVR1,KW1mengineWildCatV,KW2mengineGriffonG8D,KW2mengineMaverickV,KW2mengineVestaVR9D,KW3mengineGriffonXX,KW3mengineTitanT1,KW3mengineWildcatXR,KW5mengineGriffonC,KW5mengineTitanV]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfoEngines
+    }
+}
+
+@PART[KWsrbGlobeI,KWsrbGlobeV,KWsrbGlobeVI,KWsrbGlobeX,KWsrbGlobeX2,KWsrbGlobeX10L,KWsrbGlobeX10S,KWsrbUllage,KWsrbUllageLarge]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = solidEngines
+    }
+}
+
+@PART[KW2mengineSPS]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = monoEngines
+    }
+}
+
+// CONTROL
+@PART[KWrcsPod,KWrcsQuad,KWrcsQuad45]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rcs
+    }
+}
+
+@PART[KWSASmodule2mHalf,KWSASmodule3mHalf,KWSASmodule5mHalf]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = reactionWheels
+    }
+}
+
+// STRUCTURAL
+@PART[KWadapter2x1,KWadapter3x2,KWFlatadapter2x1,KWFlatadapter3x1,KWFlatadapter3x2,KW3mPetalAdapter,KW5x3AdapterShroud]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = adapters
+    }
+}
+
+// COUPLING
+@PART[KW1mDecoupler,KW1875mDecoupler,KW2mDecoupler,KW3mDecoupler,KW5mStageDecoupler]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = decouplers
+    }
+}
+
+@PART[KW1mDecouplerShroud,KW2mDecouplerShroud,KW3mDecouplerShroud,KW5mDecouplerShroud]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = decouplers
+    }
+}
+
+// PAYLOAD
+@PART[KW1mFairingPF,KW_1875mFairingPF,KW2mFairingPF,KW3mFairingPF,KW5mFairingPF,KW1mFairingPFE,KW_1875mFairingPFE,KW2mFairingPFE,KW3mFairingPFE,KW5mFairingPFE]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = fairings
+    }
+}
+
+// AERO
+@PART[KW1mNoseCone,KW2mNoseCone,KW3mNoseCone,KW5mNoseCone,KW2mSRBNoseCone]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = noses
+    }
+}
+
+@PART[KWFin,KWFinGC]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = controlSurfaces
+    }
+}
+
+// ELECTRICAL
+@PART[KWRadBattSmallS,KWRadBattSmallL,KWRadBattLargeS,KWRadBattLargeL]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = batteries
+    }
+}
+
+// UTILITY
+@PART[KW3mDockingRing]:NEEDS[KWRocketry]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = airlocks
+    }
+}

--- a/GameData/VABOrganizer-Sheepdog/MK3Expansion/Mk3ExpansionVABO.cfg
+++ b/GameData/VABOrganizer-Sheepdog/MK3Expansion/Mk3ExpansionVABO.cfg
@@ -1,0 +1,327 @@
+/////////////////////////////////////////////////////
+// Mk3Expansion
+/////////////////////////////////////////////////////
+
+
+// COMMAND
+@PART[M3X_ShovelCockpit,M3X_InlineCockpit]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = cockpits
+    }
+}
+
+@PART[M3XDroneCore]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = probes
+    }
+}
+
+@PART[M3X_CyclopsCockpit]:NEEDS[Mk3Expansion,!StationPartsExpansionRedux]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = pods
+    }
+}
+
+@PART[M3X_CyclopsCockpit]:NEEDS[Mk3Expansion,StationPartsExpansionRedux]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = cupolas
+    }
+}
+
+// FUEL
+@PART[M3X_UST,M3X_ShortAdapter,M3X_InverterAdaptermk2,M3X_size1adapter,M3X_Mk2Tricoupler]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+
+@PART[M3X_EndSegment,M3X_ShortSegment,M3X_LongSegment,M3X_AdapterSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfo
+    }
+}
+
+@PART[M3X_OMSShoulder]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = monoprop
+    }
+}
+
+@PART[M3X_Size2Bicoupler,M3X_Quadcoupler,M3X_Tricoupler]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = engineMount
+    }
+}
+
+// ENGINES
+@PART[M3X_Linearaerospike,M3X_ConcentricAerospike,M3X_AugmentedRocket]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = lfoEngines
+    }
+}
+
+@PART[M3X_SRB,M3X_SRBLong,M3X_HeavySRB]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = solidEngines
+    }
+}
+
+@PART[M3X_Hades,M3X_NuclearJet]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = nuclearEngines
+    }
+}
+
+@PART[M3X_HeavyVTOL,M3X_TurboJet,M3X_XLTurbofan,M3X_Turbofan]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = jetEngines
+    }
+}
+
+@PART[M3X_CLEAVER]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = jetEngines
+    }
+}
+
+@PART[M3X_Heavyprop]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = propEngines
+    }
+}
+
+@PART[mk3_OMSystem]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = monoEngines
+    }
+}
+
+@PART[M3X_IonEngine]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = ionEngines
+    }
+}
+
+// CONTROL
+@PART[M3X_HeavyRCS]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rcs
+    }
+}
+
+@PART[M3X_RCSChineCap,M3X_RCSChineSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rcs
+    }
+}
+
+@PART[M3X_RCSCap,M3X_RCSSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = rcs
+    }
+}
+
+@PART[M3X_SAS]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = reactionWheels
+    }
+}
+
+// STRUCTURAL
+@PART[M3X_Endplate,M3X_AttachSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = adapters
+    }
+}
+
+@PART[M3X_LHub,M3X_THub,M3X_XHub]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = hubs
+    }
+}
+
+@PART[M3X_RadialMount]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = radialAdapters
+    }
+}
+
+@PART[M3X_StructuralTube,M3X_LTube,M3X_Ttube,M3X_Xtube]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = tubes
+    }
+}
+
+// COUPLING
+@PART[M3Xdecoupler]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = decouplers
+    }
+}
+
+@PART[M3X_AligningDockingPort,M3X_StackDockingPort,M3X_InlineDockingPort]:NEEDS[Mk2Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = dockingPorts
+    }
+}
+
+// PAYLOAD
+@PART[M3X_serviceBay]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = serviceBays
+    }
+}
+
+@PART[M3X_NoseRamp,M3X_FlatRamp,M3X_Mk2AdapterRamp,M3X_Mk2LongAdapterRamp]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = cargoBays
+    }
+}
+
+@PART[M3X_cargoContainer]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = cargoStorage
+    }
+}
+
+// AERO
+@PART[M3X_SubsonicIntake,M3X_ConeIntake,M3X_RampIntake,M3X_IntakeSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = intakes
+    }
+}
+
+@PART[M3X_hypersonicnosecone,M3X_nosecap]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = noses
+    }
+}
+
+@PART[M3X_WingSegmentA,M3X_WingSegmentB,M3X_WingSegmentC,M3X_WingSegmentD,M3X_WingSegmentE,M3X_WingSegmentF,M3X_WingSegmentG]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = wings
+    }
+}
+
+@PART[M3X_EndChine,M3X_ShortChine,M3X_LongChine]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = wings
+    }
+}
+
+@PART[M3X_Precooler]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = airAccessories
+    }
+}
+
+@PART[M3X_ElevonA,M3X_ElevonB,M3X_ElevonC]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = controlSurfaces
+    }
+}
+
+@PART[M3X_AirbrakeA,M3X_AirbrakeB]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = deployableControlSurfaces
+    }
+}
+
+// ELECTRICAL
+@PART[M3X_Reactor]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = nuclearReactors
+    }
+}
+
+// SCIENCE
+@PART[M3X_SciLab]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = labs
+    }
+}
+
+// UTILITY
+@PART[M3X_CrewSegment]:NEEDS[Mk3Expansion]
+{
+    %VABORGANIZER
+    {
+        %organizerSubcategory = crewTransport
+    }
+}


### PR DESCRIPTION
I had these pathes as a part of my mod OCCULT, thought it would be a better idea to have them be a part of the main mod.
- Add missing parts to the AirplanePlus config
- Add complete config for KW rocketry
- Add complete config for Mk3Expansion